### PR TITLE
ci: Remove android tests from pipeline and test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -18,8 +18,6 @@ jobs:
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -33,15 +31,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Build and analyze
-        uses: reactivecircus/android-emulator-runner@v2.30.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          api-level: 30
-          target: google_apis
-          arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew build sonar --info
+        run: ./gradlew build sonar --info

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,14 +109,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
     classDirectories.setFrom(classesDir)
     sourceDirectories.setFrom(srcDir)
-    executionData.setFrom(
-        fileTree(
-            mapOf(
-                "dir" to project.projectDir,
-                "includes" to listOf("**/*.exec", "**/*.ec")
-            )
-        )
-    )
+    executionData.setFrom(files(layout.buildDirectory.asFile.get().toString() + "/jacoco/testDebugUnitTest.exec"))
 }
 
 tasks.withType<Test> {
@@ -134,7 +127,7 @@ tasks.register("testAll", JacocoReport::class) {
     finalizedBy("jacocoTestReport")
 }
 
-project.tasks["sonarqube"].dependsOn("testAll")
+project.tasks["sonarqube"].dependsOn("testDebugUnitTest")
 
 sonar {
     properties {
@@ -146,6 +139,7 @@ sonar {
             "sonar.coverage.jacoco.xmlReportPaths",
             "${project.projectDir}/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
         )
+        property("sonar.coverage.exclusions", "${project.projectDir}/src/java/at/aau/serg/activities/**")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,7 +139,7 @@ sonar {
             "sonar.coverage.jacoco.xmlReportPaths",
             "${project.projectDir}/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
         )
-        property("sonar.coverage.exclusions", "${project.projectDir}/src/java/at/aau/serg/activities/**")
+        property("sonar.coverage.exclusions", "**/at/aau/serg/activities/**")
     }
 }
 

--- a/app/src/androidTest/java/at/aau/serg/view/MainActivityTest.kt
+++ b/app/src/androidTest/java/at/aau/serg/view/MainActivityTest.kt
@@ -1,15 +1,13 @@
 package at.aau.serg.view
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import at.aau.serg.MainActivity
+import at.aau.serg.activities.MainActivity
 import at.aau.serg.R
-import junit.framework.TestCase.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:usesCleartextTraffic="true"
         >
         <activity
-            android:name=".MainActivity"
+            android:name=".activities.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -1,10 +1,11 @@
-package at.aau.serg
+package at.aau.serg.activities
 
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import at.aau.serg.R
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".activities.MainActivity">
 
     <TextView
         android:id="@+id/hellotext"


### PR DESCRIPTION
## This PR

- Removes the `activities`  folder from the test coverage
- Moves the `Mainactivity` into the `activities`  folder
- Don't execute the android tests in the pipeline