### PR TITLE
fix: Jacoco execution data for test coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,6 @@ android {
 
 tasks.register("jacocoTestReport", JacocoReport::class) {
     mustRunAfter("testDebugUnitTest")
-    mustRunAfter("createDebugCoverageReport")
 
     dependsOn(
         ":app:checkDebugDuplicateClasses",
@@ -109,25 +108,20 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
 
     classDirectories.setFrom(classesDir)
     sourceDirectories.setFrom(srcDir)
-    executionData.setFrom(files(layout.buildDirectory.asFile.get().toString() + "/jacoco/testDebugUnitTest.exec"))
+    executionData.setFrom(
+        fileTree(
+            mapOf(
+                "dir" to project.projectDir,
+                "includes" to listOf("**/*.exec", "**/*.ec")
+            )
+        )
+    )
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
     finalizedBy("jacocoTestReport")
 }
-
-tasks.register("androidTest", JacocoReport::class.java) {
-    dependsOn("connectedDebugAndroidTest")
-    finalizedBy("jacocoTestReport")
-}
-
-tasks.register("testAll", JacocoReport::class) {
-    dependsOn("testDebugUnitTest", "androidTest")
-    finalizedBy("jacocoTestReport")
-}
-
-project.tasks["sonarqube"].dependsOn("testDebugUnitTest")
 
 sonar {
     properties {


### PR DESCRIPTION
Fix the bug with SonarCloud not detecting Jacoco test coverage.