### PR TITLE
refactor: Object parameters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,7 +142,7 @@ sonar {
             "sonar.coverage.jacoco.xmlReportPaths",
             "${project.projectDir}/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
         )
-        property("sonar.coverage.exclusions", "**/at/aau/serg/activities/**")
+        property("sonar.coverage.exclusions", "**/at/aau/serg/activities/**,**/at/aau/serg/utils/App.kt")
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+
     <application
+        android:name=".utils.App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/at/aau/serg/activities/LoginActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/LoginActivity.kt
@@ -14,16 +14,11 @@ import at.aau.serg.R
 import at.aau.serg.logic.Authentication
 import at.aau.serg.logic.StoreToken
 import at.aau.serg.network.CallbackCreator
-import at.aau.serg.network.HttpClient
 import okhttp3.Response
 import org.json.JSONException
 import org.json.JSONObject
 
 class LoginActivity : AppCompatActivity() {
-
-    private lateinit var httpClient: HttpClient
-    private lateinit var authentication: Authentication
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -33,16 +28,13 @@ class LoginActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
-
-        httpClient = HttpClient.getInstance(getString(R.string.api_url))
-        authentication = Authentication.getInstance(httpClient)
     }
 
     fun btnLoginClicked(view: View) {
         val username = findViewById<EditText>(R.id.editTextUsername).text
         val password = findViewById<EditText>(R.id.editTextPassword).text
 
-        val error = authentication.loginUser(username.toString(), password.toString(), CallbackCreator().createCallback(::onFailureLogin, ::onResponseLogin))
+        val error = Authentication.loginUser(username.toString(), password.toString(), CallbackCreator().createCallback(::onFailureLogin, ::onResponseLogin))
         if(error != null){
             Toast.makeText(this, error, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -34,6 +34,8 @@ class MainActivity : AppCompatActivity() {
         httpClient = HttpClient.getInstance(getString(R.string.api_url))
         authentication = Authentication.getInstance(httpClient)
 
+
+
         if(!authentication.tokenValid(CallbackCreator().createCallback(::startLoginActivity, ::checkIfUserIsAuthenticated), StoreToken(this))){
             this.startActivity(Intent(this, LoginActivity::class.java))
         }

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -18,9 +18,6 @@ import org.json.JSONObject
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var httpClient: HttpClient
-    private lateinit var authentication: Authentication
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -31,12 +28,7 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
-        httpClient = HttpClient.getInstance(getString(R.string.api_url))
-        authentication = Authentication.getInstance(httpClient)
-
-
-
-        if(!authentication.tokenValid(CallbackCreator().createCallback(::startLoginActivity, ::checkIfUserIsAuthenticated), StoreToken(this))){
+        if(!Authentication.tokenValid(CallbackCreator().createCallback(::startLoginActivity, ::checkIfUserIsAuthenticated), StoreToken(this))){
             this.startActivity(Intent(this, LoginActivity::class.java))
         }
     }
@@ -54,7 +46,7 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
-        if(!authentication.updateToken(CallbackCreator().createCallback(::startLoginActivity, ::checkIfUpdateAccessTokenWorked), StoreToken(this@MainActivity))) {
+        if(!Authentication.updateToken(CallbackCreator().createCallback(::startLoginActivity, ::checkIfUpdateAccessTokenWorked), StoreToken(this@MainActivity))) {
             this@MainActivity.startActivity(Intent(this@MainActivity, LoginActivity::class.java))
         }
     }

--- a/app/src/main/java/at/aau/serg/activities/RegisterActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/RegisterActivity.kt
@@ -20,10 +20,6 @@ import org.json.JSONException
 import org.json.JSONObject
 
 class RegisterActivity : AppCompatActivity() {
-
-    private lateinit var httpClient: HttpClient
-    private lateinit var authentication: Authentication
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -33,16 +29,13 @@ class RegisterActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
-
-        httpClient = HttpClient.getInstance(getString(R.string.api_url))
-        authentication = Authentication.getInstance(httpClient)
     }
 
     fun btnRegisterClicked(view: View) {
         val username = findViewById<EditText>(R.id.editTextUsername).text
         val password = findViewById<EditText>(R.id.editTextPassword).text
 
-        val error = authentication.registerUser(username.toString(), password.toString(), CallbackCreator().createCallback(::onFailureRegister, ::onResponseRegister))
+        val error = Authentication.registerUser(username.toString(), password.toString(), CallbackCreator().createCallback(::onFailureRegister, ::onResponseRegister))
         if(error != null){
             Toast.makeText(this, error, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/at/aau/serg/logic/Authentication.kt
+++ b/app/src/main/java/at/aau/serg/logic/Authentication.kt
@@ -5,21 +5,14 @@ import at.aau.serg.network.HttpClient
 import com.google.gson.Gson
 import okhttp3.Callback
 
-class Authentication private constructor(private val httpClient: HttpClient) {
-    companion object{
-        @Volatile
-        private var INSTANCE: Authentication? = null
-
-        @Synchronized
-        fun getInstance(httpClient: HttpClient): Authentication = INSTANCE ?: Authentication(httpClient)
-    }
+object Authentication {
 
     fun registerUser(username: String, password: String, callback: Callback): String? {
         if(username.isEmpty() || password.isEmpty()){
             return "Username and Password cannot be empty"
         }
         val userToRegister = User(username, password)
-        httpClient.post("users/register", Gson().toJson(userToRegister), null, callback)
+        HttpClient.post("users/register", Gson().toJson(userToRegister), null, callback)
         return null
     }
 
@@ -30,14 +23,14 @@ class Authentication private constructor(private val httpClient: HttpClient) {
 
         val userToRegister = User(username, password)
 
-        httpClient.post("users/login", Gson().toJson(userToRegister), null, callback)
+        HttpClient.post("users/login", Gson().toJson(userToRegister), null, callback)
         return null
     }
 
     fun tokenValid(callback: Callback, storeToken: StoreToken): Boolean{
         val accessToken = storeToken.getAccessToken() ?: return false
 
-        httpClient.get("users/me", accessToken, callback)
+        HttpClient.get("users/me", accessToken, callback)
         return true
     }
 
@@ -48,7 +41,7 @@ class Authentication private constructor(private val httpClient: HttpClient) {
             "refreshToken": """" + refreshToken + """"
             }
         """
-        httpClient.post("users/refresh", jsonString, null, callback)
+        HttpClient.post("users/refresh", jsonString, null, callback)
         return true
     }
 

--- a/app/src/main/java/at/aau/serg/network/HttpClient.kt
+++ b/app/src/main/java/at/aau/serg/network/HttpClient.kt
@@ -9,20 +9,9 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
-class HttpClient private constructor(private val baseUrl: String) {
+object HttpClient {
     private var client: OkHttpClient = OkHttpClient()
-
-    companion object{
-        private var baseUrl: String = Strings.get(R.string.api_url)
-
-        @Volatile
-        private var INSTANCE: HttpClient? = null
-
-        @Synchronized
-        fun getInstance(baseUrl: String): HttpClient {
-            return INSTANCE ?: HttpClient(baseUrl)
-        }
-    }
+    private val baseUrl: String = Strings.get(R.string.api_url)
 
     fun post(url: String, jsonBody: String, authToken: String?, callback: Callback) {
         val body = jsonBody.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())

--- a/app/src/main/java/at/aau/serg/network/HttpClient.kt
+++ b/app/src/main/java/at/aau/serg/network/HttpClient.kt
@@ -29,7 +29,6 @@ object HttpClient {
 
     fun get(url: String, authToken: String?, callback: Callback) {
         val requestUrl = makeRequestUrl(url)
-        print(requestUrl)
         val request = Request.Builder()
             .url(requestUrl)
             .apply {

--- a/app/src/main/java/at/aau/serg/network/HttpClient.kt
+++ b/app/src/main/java/at/aau/serg/network/HttpClient.kt
@@ -11,7 +11,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 
 object HttpClient {
     private var client: OkHttpClient = OkHttpClient()
-    private val baseUrl: String = Strings.get(R.string.api_url)
+    private var baseUrl: String = Strings.get(R.string.api_url)
 
     fun post(url: String, jsonBody: String, authToken: String?, callback: Callback) {
         val body = jsonBody.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
@@ -29,6 +29,7 @@ object HttpClient {
 
     fun get(url: String, authToken: String?, callback: Callback) {
         val requestUrl = makeRequestUrl(url)
+        print(requestUrl)
         val request = Request.Builder()
             .url(requestUrl)
             .apply {
@@ -42,5 +43,10 @@ object HttpClient {
     @Throws(IllegalArgumentException::class)
     private fun makeRequestUrl(path: String): String {
         return baseUrl.toHttpUrl().newBuilder().addPathSegments(path.trimStart('/')).build().toString()
+    }
+
+    fun resetClient(baseUrl: String = Strings.get(R.string.api_url)) {
+        client = OkHttpClient()
+        this.baseUrl = baseUrl
     }
 }

--- a/app/src/main/java/at/aau/serg/network/HttpClient.kt
+++ b/app/src/main/java/at/aau/serg/network/HttpClient.kt
@@ -1,5 +1,7 @@
 package at.aau.serg.network
 
+import at.aau.serg.R
+import at.aau.serg.utils.Strings
 import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -11,11 +13,15 @@ class HttpClient private constructor(private val baseUrl: String) {
     private var client: OkHttpClient = OkHttpClient()
 
     companion object{
+        private var baseUrl: String = Strings.get(R.string.api_url)
+
         @Volatile
         private var INSTANCE: HttpClient? = null
 
         @Synchronized
-        fun getInstance(baseUrl: String): HttpClient = INSTANCE ?: HttpClient(baseUrl)
+        fun getInstance(baseUrl: String): HttpClient {
+            return INSTANCE ?: HttpClient(baseUrl)
+        }
     }
 
     fun post(url: String, jsonBody: String, authToken: String?, callback: Callback) {

--- a/app/src/main/java/at/aau/serg/utils/App.kt
+++ b/app/src/main/java/at/aau/serg/utils/App.kt
@@ -1,0 +1,14 @@
+package at.aau.serg.utils
+
+import android.app.Application
+
+class App : Application() {
+    companion object {
+        lateinit var instance: App private set
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+}

--- a/app/src/main/java/at/aau/serg/utils/Strings.kt
+++ b/app/src/main/java/at/aau/serg/utils/Strings.kt
@@ -1,0 +1,9 @@
+package at.aau.serg.utils
+
+import androidx.annotation.StringRes
+
+object Strings {
+    fun get(@StringRes stringRes: Int, vararg formatArgs: Any = emptyArray()): String {
+        return App.instance.getString(stringRes, *formatArgs)
+    }
+}


### PR DESCRIPTION
After some research, I found a way/workaround to access string resources in classes outside of the app module/context. This allowed us to remove the parameters from the `HttpClient` and `Authentication` classes, but it's up to discussion if we want to add this workaround to the app.

## Issue

Fixes #24 