### PR TITLE
fix: Gamescreen fragment

### DIFF
--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -38,25 +38,37 @@ class GameScreenActivity : AppCompatActivity() {
         val gameScreen = getGameScreen()
         if (gameScreen != null) {
             val transaction = supportFragmentManager.beginTransaction()
-            transaction.replace(R.id.fragmentView_GameScreen, gameScreen)
+            transaction.replace(R.id.game_fragment_container_view, gameScreen)
             transaction.commit()
         }
 
     }
 
     // only for showing the different GameScreens now
-    fun getGameScreen(): Fragment? {
+    fun getGameScreen(): Fragment {
         val randomInt = (3..6).random()
         return when (randomInt){
             3 -> GameScreenThreePlayersFragment()
             4 -> GameScreenFourPlayersFragment()
             5 -> GameScreenFivePlayersFragment()
             6 -> GameScreenSixPlayersFragment()
-            else -> null
+            else -> GameScreenThreePlayersFragment()
         }
     }
 
     fun btnMenuClicked(view: View){
         startActivity(Intent(this, MainActivity::class.java))
+    }
+
+    fun btnChangeFragmentClicked(view: View) {
+        val fragment = supportFragmentManager.findFragmentById(R.id.game_fragment_container_view)
+        val newFragment = when (fragment) {
+            is TrickPredictionFragment -> getGameScreen()
+            else -> TrickPredictionFragment()
+        }
+
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.game_fragment_container_view, newFragment)
+            .commit()
     }
 }

--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -45,14 +45,14 @@ class GameScreenActivity : AppCompatActivity() {
     }
 
     // only for showing the different GameScreens now
-    fun getGameScreen(): Fragment {
+    fun getGameScreen(): Fragment? {
         val randomInt = (3..6).random()
         return when (randomInt){
             3 -> GameScreenThreePlayersFragment()
             4 -> GameScreenFourPlayersFragment()
             5 -> GameScreenFivePlayersFragment()
             6 -> GameScreenSixPlayersFragment()
-            else -> GameScreenThreePlayersFragment()
+            else -> null
         }
     }
 
@@ -67,8 +67,10 @@ class GameScreenActivity : AppCompatActivity() {
             else -> TrickPredictionFragment()
         }
 
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.game_fragment_container_view, newFragment)
-            .commit()
+        if (newFragment != null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.game_fragment_container_view, newFragment)
+                .commit()
+        }
     }
 }

--- a/app/src/main/res/layout/activity_game_screen.xml
+++ b/app/src/main/res/layout/activity_game_screen.xml
@@ -15,6 +15,26 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/btnMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:onClick="btnMenuClicked"
+        android:text="@string/menu"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnShowPoints" />
+
+    <Button
+        android:id="@+id/btnChangeFragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:onClick="btnChangeFragmentClicked"
+        android:textSize="12sp"
+        android:text="@string/changeFragment"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnMenu" />
+
     <TextView
         android:id="@+id/roundCountTV"
         android:layout_width="wrap_content"
@@ -37,24 +57,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <FrameLayout
-        android:id="@+id/fragmentView_GameScreen"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="70dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.5" />
-
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/game_fragment_container_view"
         android:name="at.aau.serg.fragments.TrickPredictionFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintHeight_percent="0.50"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp"
+        app:layout_constraintHeight_percent="0.55"
         app:layout_constraintTop_toBottomOf="@+id/trumpCardImageView" />
 
     <androidx.fragment.app.FragmentContainerView
@@ -62,21 +72,12 @@
         android:name="at.aau.serg.fragments.CardsFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintHeight_percent="0.30"
+        app:layout_constraintHeight_percent="0.25"
         app:layout_constraintTop_toBottomOf="@id/game_fragment_container_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <Button
-        android:id="@+id/btnMenu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="18dp"
-        android:layout_marginTop="50dp"
-        android:onClick="btnMenuClicked"
-        android:text="@string/menu"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_game_screen.xml
+++ b/app/src/main/res/layout/activity_game_screen.xml
@@ -62,9 +62,7 @@
         android:name="at.aau.serg.fragments.TrickPredictionFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:paddingTop="16dp"
-        android:paddingBottom="16dp"
-        app:layout_constraintHeight_percent="0.55"
+        app:layout_constraintHeight_percent="0.60"
         app:layout_constraintTop_toBottomOf="@+id/trumpCardImageView" />
 
     <androidx.fragment.app.FragmentContainerView
@@ -72,7 +70,7 @@
         android:name="at.aau.serg.fragments.CardsFragment"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintHeight_percent="0.20"
         app:layout_constraintTop_toBottomOf="@id/game_fragment_container_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="confirm">Confirm</string>
     <string name="roundPlaceholder">Round: 1 of 15</string>
     <string name="menu">Menu</string>
+    <string name="changeFragment">Change fragment</string>
 </resources>


### PR DESCRIPTION
## This PR

- Fixed the overlap of the game screen and trick prediction fragments (since they were using two separate fragment containers) and the cutoff of the cards for the game screen fragments with four, five and six cards.
- Adds a switch fragment button that can be used for switching between the game screen and trick prediction fragments (will later be replaced by our game lifecycle)


<img src="https://github.com/SE2Project-BHKPTZ/frontend/assets/40315960/6f42537d-b9f8-4854-928a-dfeaf1bf7dd8" width="300" height="600">

<img src="https://github.com/SE2Project-BHKPTZ/frontend/assets/40315960/b179f5a3-4741-4a24-861c-361cb4f664f6)" width="300" height="600">



Issues that are still open:

- The game screen fragments use hard-coded height and width and are therefore cut off if the container gets too small (can only be correctly displayed on larger devices) 