### PR TITLE
feat: Increase round

### DIFF
--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.activities
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -258,11 +259,14 @@ class GameScreenActivity : AppCompatActivity() {
         increaseRoundCount()
     }
 
+    @SuppressLint("SetTextI18n")
     private fun increaseRoundCount() {
-        trickViewModel.increaseRound()
+        this.runOnUiThread {
+            trickViewModel.increaseRound()
 
-        val roundCountTextView: TextView = findViewById(R.id.tvRoundCount)
-        roundCountTextView.text = trickViewModel.round.value.toString()
+            val roundCountTextView: TextView = findViewById(R.id.tvRoundCount)
+            roundCountTextView.text = "Round: ${trickViewModel.round.value.toString()} of ${getMaxRoundCount()}"
+        }
     }
 
     private fun nextPlayer(socketResponse: Array<Any>){
@@ -280,6 +284,16 @@ class GameScreenActivity : AppCompatActivity() {
         cardPlayed = false
         lastPlayedCard = null
         countPlayedCards = 0
+    }
+
+    private fun getMaxRoundCount(): Int {
+        return when(playerCount) {
+            3 -> 20
+            4 -> 15
+            5 -> 12
+            6 -> 10
+            else -> 20
+        }
     }
 
     fun setPlayerGameScreen() {

--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -252,6 +253,16 @@ class GameScreenActivity : AppCompatActivity() {
         val newFragment = TrickPredictionFragment()
         clearCardPlayedEvents()
         updateFragmentContainerView(newFragment)
+
+        // TODO: Increase round count
+        increaseRoundCount()
+    }
+
+    private fun increaseRoundCount() {
+        trickViewModel.increaseRound()
+
+        val roundCountTextView: TextView = findViewById(R.id.tvRoundCount)
+        roundCountTextView.text = trickViewModel.round.value.toString()
     }
 
     private fun nextPlayer(socketResponse: Array<Any>){

--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -53,7 +53,7 @@ class GameScreenActivity : AppCompatActivity() {
         }
 
         updateFragmentContainerView(TrickPredictionFragment())
-        trickViewModel.setRound(1)
+        initializeRoundCount()
 
         val initialCards: Array<CardItem>?
         val initialTrumpCard: CardItem?
@@ -255,17 +255,20 @@ class GameScreenActivity : AppCompatActivity() {
         clearCardPlayedEvents()
         updateFragmentContainerView(newFragment)
 
-        // TODO: Increase round count
         increaseRoundCount()
     }
 
-    @SuppressLint("SetTextI18n")
+    private fun initializeRoundCount() {
+        this.runOnUiThread {
+            trickViewModel.setRound(1)
+            findViewById<TextView>(R.id.tvRoundCount).text = getString(R.string.gameRoundPlaceholder, 1, getMaxRoundCount())
+        }
+    }
+
     private fun increaseRoundCount() {
         this.runOnUiThread {
             trickViewModel.increaseRound()
-
-            val roundCountTextView: TextView = findViewById(R.id.tvRoundCount)
-            roundCountTextView.text = "Round: ${trickViewModel.round.value.toString()} of ${getMaxRoundCount()}"
+            findViewById<TextView>(R.id.tvRoundCount).text = getString(R.string.gameRoundPlaceholder, trickViewModel.round.value ?: 0, getMaxRoundCount())
         }
     }
 

--- a/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
@@ -180,6 +180,11 @@ class LobbyActivity : AppCompatActivity() {
         intent.putExtra("playerCount", gameData.getJSONArray("hands").length())
         intent.putExtra("me", getPlayerIndex())
 
+        SocketHandler.off("lobby:userJoined")
+        SocketHandler.off("lobby:userLeft")
+        SocketHandler.off("lobby:userKick")
+        SocketHandler.off("startGame")
+
         startActivity(intent)
     }
 

--- a/app/src/main/java/at/aau/serg/network/SocketHandler.kt
+++ b/app/src/main/java/at/aau/serg/network/SocketHandler.kt
@@ -35,6 +35,10 @@ object SocketHandler {
         }
     }
 
+    fun off(eventName: String) {
+        socket.off(eventName)
+    }
+
     fun setupBasicListeners() {
         on(Socket.EVENT_CONNECT) {
             Log.i("socket", "Connected")

--- a/app/src/main/java/at/aau/serg/viewmodels/TrickPredictionViewModel.kt
+++ b/app/src/main/java/at/aau/serg/viewmodels/TrickPredictionViewModel.kt
@@ -11,4 +11,8 @@ class TrickPredictionViewModel: ViewModel() {
     fun setRound(data: Int) {
         _round.value = data
     }
+
+    fun increaseRound() {
+        _round.value = _round.value?.plus(1)
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="gamePredictTrickNumber">Predict the number of tricks for this round!</string>
     <string name="gamePredictionScore">Highest score with your Prediction:</string>
     <string name="gameConfirm">Confirm</string>
-    <string name="gameRoundPlaceholder">Round: 1 of 15</string>
+    <string name="gameRoundPlaceholder">Round: %1$d of %2$d</string>
     <string name="tmpMenu">Menu</string>
     <string name="tmpChangeFragment">Change fragment</string>
     <string name="gamePlayer1Card">Player 1 Card</string>

--- a/app/src/test/java/at/aau/serg/network/SocketHandlerTest.kt
+++ b/app/src/test/java/at/aau/serg/network/SocketHandlerTest.kt
@@ -95,4 +95,14 @@ class SocketHandlerTest {
         verify(exactly = 1) { Log.i("socket", "Connected") }
         verify(exactly = 1) { Log.i("socket", "Disconnected") }
     }
+
+    @Test
+    fun `off removes the correct event listener`() {
+        SocketHandler.connect("uuid")
+
+        val eventName = "testEvent"
+        SocketHandler.off(eventName)
+
+        verify { mockSocket.off(eventName) }
+    }
 }


### PR DESCRIPTION
## This PR

- Increases the round count in the trick prediction fragment and game screen UI
- Removes socket handlers when we leave the activity (I believe they are still called when the event is received even though the functions are not ready anymore)