### PR TITLE
feat: Add default value to trick prediction screen

### DIFF
--- a/app/src/main/res/layout/fragment_trick_prediction.xml
+++ b/app/src/main/res/layout/fragment_trick_prediction.xml
@@ -49,6 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:textStyle="bold"
+            android:text="@string/defaultPredictionScore"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tvPredictionScoreInfo" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="gamePlayer5Card">Player 5 Card</string>
     <string name="gamePlayer6Card">Player 6 Card</string>
     <string name="gameNoPoints">00</string>
+    <string name="defaultPredictionScore">20 Points</string>
 </resources>


### PR DESCRIPTION
When entering the trick prediction screen, we didn't display an initial point value since the value was only added when changing the slider. This PR adds a default value of 20 (no trick); see images:

<img src="https://github.com/SE2Project-BHKPTZ/frontend/assets/40315960/7fca313d-9878-4cc8-a265-030d56044fa7" alt="alt text" width="300">
<img src="https://github.com/SE2Project-BHKPTZ/frontend/assets/40315960/abfde982-1cc8-4ebc-bf78-0f5af8b04461" alt="alt text" width="300">