### PR TITLE
fix: recovery in last round

### DIFF
--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -114,7 +114,13 @@ class GameScreenActivity : AppCompatActivity() {
 
         val cards = removePlayedCard(gameData.round.deck.hands[myPlayerIndex], getAllPlayedCards(gameData.round.subrounds))
         setCards(cards.toTypedArray())
-        setupTrumpCard(gameData.round.deck.trump)
+        if(gameData.round.deck.trump != null){
+            setupTrumpCard(gameData.round.deck.trump)
+        }else {
+            val trumpImageView: ImageView = findViewById(R.id.ivTrumpCard)
+            trumpImageView.visibility = Visibilities.INVISIBLE.value
+        }
+
 
         maxRounds = gameData.maxRounds
         initializeRoundCount(gameData.currentRound)

--- a/app/src/main/java/at/aau/serg/models/Deck.kt
+++ b/app/src/main/java/at/aau/serg/models/Deck.kt
@@ -2,4 +2,4 @@ package at.aau.serg.models
 
 import java.io.Serializable
 
-data class Deck (val hands: List<List<CardItem>>, val trump: CardItem): Serializable
+data class Deck (val hands: List<List<CardItem>>, val trump: CardItem?): Serializable


### PR DESCRIPTION
if user reconnects in the last round, the app crashed

The problem was that the recovery data class had no nullable trump