### PR TITLE
fix: Polling bug + Remove unused code

### DIFF
--- a/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/GameScreenActivity.kt
@@ -68,11 +68,15 @@ class GameScreenActivity : AppCompatActivity() {
 
         updateFragmentContainerView(TrickPredictionFragment())
         handleIntentData()
+    }
+
+    override fun onStart() {
+        super.onStart()
         setupSocketHandlers()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onStop() {
+        super.onStop()
         removeSocketHandlers()
     }
 

--- a/app/src/main/java/at/aau/serg/activities/JoinLobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/JoinLobbyActivity.kt
@@ -103,8 +103,6 @@ class JoinLobbyActivity : AppCompatActivity() {
             runOnUiThread {
                 adapter.notifyDataSetChanged()
             }
-
-            Log.d("LO", lobbies.toString())
         }
     }
 

--- a/app/src/main/java/at/aau/serg/activities/JoinLobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/JoinLobbyActivity.kt
@@ -183,8 +183,8 @@ class JoinLobbyActivity : AppCompatActivity() {
         startActivity(Intent(this, MainActivity::class.java))
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onStop() {
+        super.onStop()
         handler.removeCallbacks(pollingRunnable)
     }
 }

--- a/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
@@ -62,15 +62,18 @@ class LobbyActivity : AppCompatActivity() {
             StoreToken(this).getAccessToken(),
             CallbackCreator().createCallback(::onFailure, ::onSuccessGetLobby)
         )
+    }
 
+    override fun onStart() {
+        super.onStart()
         SocketHandler.on("lobby:userJoined", ::userJoined)
         SocketHandler.on("lobby:userLeft", ::userLeft)
         SocketHandler.on("lobby:userKick", ::userKick)
         SocketHandler.on("startGame", ::startGame)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onStop() {
+        super.onStop()
         SocketHandler.off("lobby:userJoined")
         SocketHandler.off("lobby:userLeft")
         SocketHandler.off("lobby:userKick")

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -55,8 +55,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onStop() {
+        super.onStop()
         SocketHandler.off("recovery")
     }
 

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -122,53 +122,12 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun btnGoToLoginClicked(view: View) {
-        startActivity(Intent(this, LoginActivity::class.java))
-    }
-
-    fun openGameActivity(view: View){
-        val intent = Intent(
-            baseContext,
-            GameScreenActivity::class.java
-        )
-
-        val sampleCards: Array<CardItem> = arrayOf(
-            CardItem("2", Suit.HEARTS),
-            CardItem("5", Suit.SPADES),
-            CardItem("7", Suit.DIAMONDS),
-            CardItem("13", Suit.CLUBS),
-            CardItem("4", Suit.HEARTS)
-        )
-        intent.putExtra("cards", sampleCards)
-        intent.putExtra("trump", CardItem("3", Suit.HEARTS))
-        intent.putExtra("playerCount", 4)
-        intent.putExtra("me", 0)
-
-        startActivity(intent)
-    }
-
     fun btnCLobbyClicked(view: View) {
         startActivity(Intent(this, CreateLobbyActivity::class.java))
     }
 
     fun btnJLobbyClicked(view: View) {
         startActivity(Intent(this, JoinLobbyActivity::class.java))
-    }
-
-    fun openResultActivity(view: View) {
-        val scores = hashMapOf(
-            "1" to Score("60", 1),
-            "2" to Score("100", 2),
-            "3" to Score("20", 3)
-        )
-
-        val players = arrayOf(LobbyPlayer("1", "Player 1", Visibilities.VISIBLE), LobbyPlayer("2", "Player 2", Visibilities.VISIBLE), LobbyPlayer("3", "Player 3", Visibilities.VISIBLE))
-
-        val intent = Intent(this, ResultActivity::class.java).apply {
-            putExtra("scores", scores)
-            putExtra("players", players)
-        }
-        startActivity(intent)
     }
 
     private fun recoverGameState(socketResponse: Array<Any>) {

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -13,11 +13,6 @@ import at.aau.serg.androidutils.GameUtils.parseGameDataJson
 import at.aau.serg.androidutils.GameUtils.parseLobbyJson
 import at.aau.serg.logic.Authentication
 import at.aau.serg.logic.StoreToken
-import at.aau.serg.models.CardItem
-import at.aau.serg.models.LobbyPlayer
-import at.aau.serg.models.Score
-import at.aau.serg.models.Suit
-import at.aau.serg.models.Visibilities
 import at.aau.serg.network.CallbackCreator
 import at.aau.serg.network.SocketHandler
 import okhttp3.Response

--- a/app/src/main/java/at/aau/serg/adapters/JoinLobbyLobbiesAdapter.kt
+++ b/app/src/main/java/at/aau/serg/adapters/JoinLobbyLobbiesAdapter.kt
@@ -9,7 +9,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import at.aau.serg.R
 import at.aau.serg.activities.LobbyActivity
@@ -24,14 +23,11 @@ import okhttp3.Response
 import java.io.IOException
 
 
-class JoinLobbyLobbiesAdapter(context: ContextWrapper, listdata: MutableList<JoinLobbyLobby>) :
-    RecyclerView.Adapter<JoinLobbyLobbiesAdapter.ViewHolder>() {
+class JoinLobbyLobbiesAdapter(
+    private val context: ContextWrapper,
     private val listdata: MutableList<JoinLobbyLobby>
-    private val context:ContextWrapper
-    init {
-        this.listdata = listdata
-        this.context = context
-    }
+) :
+    RecyclerView.Adapter<JoinLobbyLobbiesAdapter.ViewHolder>() {
 
     private var lobbyID = ""
 
@@ -93,16 +89,8 @@ class JoinLobbyLobbiesAdapter(context: ContextWrapper, listdata: MutableList<Joi
     }
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        var btnJoin: Button
-        var txtLobbyName: TextView
-        var txtPlayerCount: TextView
-        var constraintLayout: ConstraintLayout
-
-        init {
-            btnJoin = itemView.findViewById<View>(R.id.btnJoin) as Button
-            txtLobbyName = itemView.findViewById<View>(R.id.tvLobbyName) as TextView
-            txtPlayerCount = itemView.findViewById<View>(R.id.tvPlayerCount) as TextView
-            constraintLayout = itemView.findViewById<View>(R.id.constraintLayout) as ConstraintLayout
-        }
+        var btnJoin: Button = itemView.findViewById<View>(R.id.btnJoin) as Button
+        var txtLobbyName: TextView = itemView.findViewById<View>(R.id.tvLobbyName) as TextView
+        var txtPlayerCount: TextView = itemView.findViewById<View>(R.id.tvPlayerCount) as TextView
     }
 }

--- a/app/src/main/java/at/aau/serg/adapters/LobbyPlayerAdapter.kt
+++ b/app/src/main/java/at/aau/serg/adapters/LobbyPlayerAdapter.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import at.aau.serg.R
 import at.aau.serg.androidutils.ErrorUtils.showToast
@@ -38,9 +37,8 @@ class LobbyPlayerAdapter(private val context: ContextWrapper, private val listda
         val player: LobbyPlayer = listdata[position]
         holder.txtPlayerName.text = player.name
         holder.btnKick.visibility = player.isVisible.value
-        holder.btnKick.setOnClickListener { view ->
+        holder.btnKick.setOnClickListener {
             kickPlayer(player)
-            showToast(view.context,"click on item: " + player.uuid)
         }
     }
 
@@ -68,14 +66,7 @@ class LobbyPlayerAdapter(private val context: ContextWrapper, private val listda
     }
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        var btnKick: Button
-        var txtPlayerName: TextView
-        var constraintLayout: ConstraintLayout
-
-        init {
-            btnKick = itemView.findViewById<View>(R.id.btnKick) as Button
-            txtPlayerName = itemView.findViewById<View>(R.id.tvPlayerName) as TextView
-            constraintLayout = itemView.findViewById<View>(R.id.constraintLayout) as ConstraintLayout
-        }
+        val btnKick: Button = itemView.findViewById<View>(R.id.btnKick) as Button
+        val txtPlayerName: TextView = itemView.findViewById<View>(R.id.tvPlayerName) as TextView
     }
 }

--- a/app/src/main/java/at/aau/serg/fragments/CardsFragment.kt
+++ b/app/src/main/java/at/aau/serg/fragments/CardsFragment.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Observer
 import at.aau.serg.R
 import at.aau.serg.activities.GameScreenActivity
 import at.aau.serg.adapters.CardsRecyclerViewAdapter
-import at.aau.serg.androidutils.ErrorUtils.showToast
 import at.aau.serg.models.CardItem
 import at.aau.serg.viewmodels.CardsViewModel
 import at.aau.serg.viewmodels.GameScreenViewModel

--- a/app/src/main/java/at/aau/serg/fragments/CardsFragment.kt
+++ b/app/src/main/java/at/aau/serg/fragments/CardsFragment.kt
@@ -54,7 +54,6 @@ class CardsFragment : Fragment() {
 
     private fun onCardClicked(cardItem: CardItem) {
         val activity = activity
-        context?.let { showToast(it, "Card clicked: ${cardItem.value} of ${cardItem.suit}") }
         if (activity is GameScreenActivity && activity.supportFragmentManager.findFragmentById(R.id.fragmentContainerViewGame) !is TrickPredictionFragment) {
             val cardIsPlayed = activity.onCardClicked(cardItem)
             if (cardIsPlayed.not()) return


### PR DESCRIPTION
## This PR

- Removes the polling handler and socket handlers in `onStop` since `onDestroy` was not called (it was still fetching lobbies even in the lobby and game screens).
- Remove toast when clicking on a card
- Remove unused temporary code from `MainActivity`