### PR TITLE
fix: Socket not initialized error

### DIFF
--- a/app/src/main/java/at/aau/serg/network/SocketHandler.kt
+++ b/app/src/main/java/at/aau/serg/network/SocketHandler.kt
@@ -34,13 +34,17 @@ object SocketHandler {
     }
 
     fun on(eventName: String, callback: (Array<Any>) -> Unit) {
-        socket.on(eventName) { args ->
-            callback(args)
+        if (::socket.isInitialized) {
+            socket.on(eventName) { args ->
+                callback(args)
+            }
         }
     }
 
     fun off(eventName: String) {
-        socket.off(eventName)
+        if (::socket.isInitialized) {
+            socket.off(eventName)
+        }
     }
 
     fun setupBasicListeners() {


### PR DESCRIPTION
When opening the `MainActivity` the Socket connection is only established/initialized when the user is authenticated, but we try to remove and event in `onStop` that gets called when we navigate to the `LoginActivity`. Therefore the app crashes if we don't handle this in the off event. 