### PR TITLE
fix: Leave lobby screen if connection is lost

### DIFF
--- a/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/LobbyActivity.kt
@@ -83,6 +83,7 @@ class LobbyActivity : AppCompatActivity() {
         SocketHandler.on("lobby:userKick", ::userKick)
         SocketHandler.on("startGame", ::startGame)
         SocketHandler.on("lobby:disconnect", ::userLeft)
+        SocketHandler.on("disconnect", ::leaveLobbyEvent)
     }
 
     override fun onStop() {
@@ -91,6 +92,7 @@ class LobbyActivity : AppCompatActivity() {
         SocketHandler.off("lobby:userLeft")
         SocketHandler.off("lobby:userKick")
         SocketHandler.off("startGame")
+        SocketHandler.off("disconnect")
     }
 
     private fun onSuccessGetLobby(response: Response) {
@@ -170,6 +172,12 @@ class LobbyActivity : AppCompatActivity() {
             StoreToken(this).getAccessToken(),
             CallbackCreator().createCallback(::onFailureLeaveLobby, ::leftLobby)
         )
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun leaveLobbyEvent(socketResponse: Array<Any>) {
+        showToast(this, "Left lobby since connection was lost")
+        startActivity(Intent(this, MainActivity::class.java))
     }
 
     fun btnStartGame(view: View) {

--- a/app/src/main/java/at/aau/serg/activities/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/activities/MainActivity.kt
@@ -130,13 +130,7 @@ class MainActivity : AppCompatActivity() {
         val data = (socketResponse[0] as JSONObject)
         val status = data.getString("status")
 
-        if (status == "JOIN_LOBBY") {
-            val lobby = parseLobbyJson(data.getJSONObject("state"))
-
-            val intent = Intent(this, LobbyActivity::class.java)
-            intent.putExtra("lobbyCode", lobby.uuid)
-            startActivity(intent)
-        } else if (status == "PLAYING") {
+       if (status == "PLAYING") {
             val gameData = parseGameDataJson(data.getJSONObject("state"))
             Log.d("gamedata", gameData.toString())
 


### PR DESCRIPTION
When the internet connection was lost, the player left the lobby (on the backend, visible to other players), but the player was left on the lobby screen without receiving any notifications.